### PR TITLE
Fix prototype mismatch errors

### DIFF
--- a/lib/sdk_ontology/sdk_ontologyImpl.pm
+++ b/lib/sdk_ontology/sdk_ontologyImpl.pm
@@ -23,7 +23,7 @@ use GenomeAnnotationAPI::GenomeAnnotationAPIClient;
 use Config::IniFiles;
 use Data::Dumper;
 use JSON;
-use JSON::XS;
+use JSON::XS ();
 binmode STDOUT, ":utf8";
 our $EC_PATTERN = qr/\(\s*E\.?C\.?(?:\s+|:)(\d\.(?:\d+|-)\.(?:\d+|-)\.(?:n?\d+|-)\s*)\)/;
 


### PR DESCRIPTION
Prototype mismatch: sub sdk_ontology::sdk_ontologyImpl::to_json ($@) vs ($) at /usr/share/perl/5.18/Exporter.pm line 66.
 at /kb/module/test/../lib/sdk_ontology/sdk_ontologyImpl.pm line 28.